### PR TITLE
make module exportable

### DIFF
--- a/js/typetura.js
+++ b/js/typetura.js
@@ -1,22 +1,30 @@
-(function(){
-  document.addEventListener( 'DOMContentLoaded', function () {
-    // On resize recalculate width
-    window.addEventListener('resize', typetura);
-    var e = document.getElementById('typetura') || document.body;
-    
-    // Query the width of the typetura container
-    function typetura() {
-      document.body.style.setProperty('--tt-width',e.offsetWidth);
-    };
+function initializeTypetura(element) {
+  // Query the width of the typetura container
+  function typetura() {
+    document.body.style.setProperty('--tt-width', element.offsetWidth);
+  };
 
-    // Create a stylesheet for typetura's custom properties
-    var s = document.createElement("style");
-    // Typetura's custom properties
-    s.innerHTML = "body{--tt-ease:linear;--tt-max:1600;--tt-bind:var(--tt-width);}*{--tt-key:'';animation:var(--tt-key) 1s var(--tt-ease) 1 calc(-1s*var(--tt-bind)/var(--tt-max)) paused}";
-    // Write typetura proprties to the top of the document head to avoid cascade conflicts
-    document.head.insertBefore(s, document.head.firstChild);
+  // On resize recalculate width
+  window.addEventListener('resize', typetura);
+
+  // Create a stylesheet for typetura's custom properties
+  var stylesheet = document.createElement("style");
+  // Typetura's custom properties
+  stylesheet.innerHTML = "body{--tt-ease:linear;--tt-max:1600;--tt-bind:var(--tt-width);}*{--tt-key:'';animation:var(--tt-key) 1s var(--tt-ease) 1 calc(-1s*var(--tt-bind)/var(--tt-max)) paused}";
+  // Write typetura proprties to the top of the document head to avoid cascade conflicts
+  document.head.insertBefore(stylesheet, document.head.firstChild);
+}
+
+if (typeof exports !== 'undefined') {
+   if (typeof module !== 'undefined' && module.exports) {
+      exports = module.exports = initializeTypetura;
+   }
+  exports.initializeTypetura = initializeTypetura;
+} else {
+  document.addEventListener( 'DOMContentLoaded', function () {
+    var element = document.getElementById('typetura') || document.body;
 
     // Initialize width variable
-    typetura();
+    initializeTypetura(element);
   });
-})();
+}

--- a/js/typetura.js
+++ b/js/typetura.js
@@ -1,4 +1,4 @@
-function initializeTypetura(element) {
+function typeturaInit(element) {
   // Query the width of the typetura container
   function typetura() {
     document.body.style.setProperty('--tt-width', element.offsetWidth);
@@ -17,14 +17,14 @@ function initializeTypetura(element) {
 
 if (typeof exports !== 'undefined') {
    if (typeof module !== 'undefined' && module.exports) {
-      exports = module.exports = initializeTypetura;
+      exports = module.exports = typeturaInit;
    }
-  exports.initializeTypetura = initializeTypetura;
+  exports.typeturaInit = typeturaInit;
 } else {
   document.addEventListener( 'DOMContentLoaded', function () {
     var element = document.getElementById('typetura') || document.body;
 
     // Initialize width variable
-    initializeTypetura(element);
+    typeturaInit(element);
   });
 }


### PR DESCRIPTION
What i'm thinking here is that when we want to use this via import we would initialize it and pass it the element to target.
ex.
```
import { typeturaInit } from 'typeturajs';
...
   componentDidMount() {
     typeturaInit('document.getElementById('main-container');
   }
```

What do you think about this? 